### PR TITLE
added cli only option to config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -128,10 +128,21 @@ fn interact(tty: &mut impl io::Write, args: &Args, config: &mut config::Config) 
 /// Writes the selected entry's value to stdout, or if `--exec` / `--exec-with` is provided,
 /// executes it.
 // TODO clean this up
-fn submit(tty: &mut impl io::Write, args: &Args, selection: String) -> Result<()> {
+fn submit(tty: &mut impl io::Write, args: &Args, mut selection: String) -> Result<()> {
     execute!(tty, Clear(ClearType::All), MoveTo(0, 0))?;
     if args.exec {
         // --exec
+
+        // check if config for item contains CLI-APP attribute
+        if selection.starts_with("CLI-APP") {
+            selection = selection.replace("CLI-APP ", "");
+            let mut keywords = selection.split(" ").collect::<Vec<&str>>();
+            let cmd = keywords[0];
+            keywords.remove(0);
+            Command::new(cmd).arg(keywords.join(" ")).spawn()?.wait()?;
+            return Ok(());
+        }
+        
         Command::new("nohup")
             .arg(selection)
             .stdin(Stdio::null())


### PR DESCRIPTION
i've added an option in the submit function so that adding CLI-APP before the command to be executed in menu.toml will result in the command being executed in an environment where the app does work purely on the command line, in the original shell where the fr33zmenu command was run,

my implementation isnt the best, but it provides me personally with a fix to my biggest obstacle to using this project and integrating it into my linux desktop

![image](https://user-images.githubusercontent.com/80643031/224689204-75823604-d1a0-43f9-9288-216fd80fdc7f.png)
(adding the CLI-APP prefix lets the second command run as intended)
